### PR TITLE
Add new Dockerfile for a python3.8-cyvcf2-venv image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+# [] -
+- Added a Dockefile for the `python3.8-cyvcf2-venv` image

--- a/python3.8-cyvcf2-venv/Dockerfile
+++ b/python3.8-cyvcf2-venv/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.8-slim
+
+ENV PATH="/venv/bin:$PATH"
+
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get -y install -y --no-install-recommends gcc libc-dev libz-dev
+
+# Install virtualenv
+RUN pip install virtualenv
+RUN virtualenv --seeder pip /venv
+
+RUN pip install --no-cache-dir "cyvcf2<0.10.0"


### PR DESCRIPTION
### This PR adds | fixes:
- Added a Dockerfile for a base images containing Python 3.8 with cyvcf2 installed insided a virtual environment

### How to test:
- [x] Build the image with the command: `docker build -t python3.8-cyvcf2-venv --file python3.8-cyvcf2-venv/Dockerfile`

### Expected outcome:
- [x] There should be no build errors 

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
