### PR TITLE
Added a Dockefile for python3.7.3-slim-stretch-cyvcf2-venv image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 # [] -
 - Added a Dockefile for the `python3.8-cyvcf2-venv` image
+- Added a Dockefile for the `python3.7.3-slim-stretch-cyvcf2-venv` image

--- a/python3.7.3-slim-stretch-cyvcf2-venv/Dockerfile
+++ b/python3.7.3-slim-stretch-cyvcf2-venv/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.7.3-slim-stretch
+
+ENV PATH="/venv/bin:$PATH"
+
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get -y install -y --no-install-recommends gcc libc-dev libz-dev
+
+# Install virtualenv
+RUN pip install virtualenv
+RUN virtualenv --seeder pip /venv
+
+RUN pip install --no-cache-dir "cyvcf2<0.10.0"


### PR DESCRIPTION
### This PR adds | fixes:
- Adds an image based on python3.7.3-slim-stretch, which **gives the possibility to install a small JVM relatively easily**.

### How to test:
- Build by executing: `docker build -t python3.7.3-slim-stretch-cyvcf2-venv --file python3.7.3-slim-stretch-cyvcf2-venv/Dockerfile  .`

### Expected outcome:
- [ ] Image should build without errors

### Review:
- [ ] Code approved by
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
