### PR TITLE
Added python3.8-slim-bedtools-venv Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# [1.0.1]
+# [1.1] 2022-02-01
+- Added a `python3.8-slim-bedtools-venv` Dockerfile
+
+# [1.0.1] 2022-02-01
 - Unfreeze cyvcf2 versions
 
 # [1.0.0] -

--- a/python3.8-slim-bedtools-venv/Dockerfile
+++ b/python3.8-slim-bedtools-venv/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.8-slim
+
+ENV PATH="/venv/bin:$PATH"
+
+# Install base dependencies
+RUN apt-get update && \
+     apt-get -y upgrade && \
+     apt-get install -y --no-install-recommends wget build-essential gcc zlib1g-dev && \
+     apt-get clean && \
+     rm -rf /var/lib/apt/lists/*
+
+# Download and install bedtools static binary
+RUN cd /usr/local/bin && \
+    wget -q https://github.com/arq5x/bedtools2/releases/download/v2.29.2/bedtools.static.binary && \
+    mv bedtools.static.binary bedtools && \
+    chmod +x bedtools
+
+# Install virtualenv
+RUN pip install virtualenv
+RUN virtualenv --seeder pip /venv


### PR DESCRIPTION
### This PR adds | fixes:
- Adds a Dockerfile based on python3.8-slim with a virtual environment and bedtools installed.

**How to prepare for test**:
- [x] Build the image
### How to test:
- [x] Launch an interactive shell from the container and invoke the bedtools command

### Expected outcome:
- [x] Bedtools command should work

### Review:
- [ ] Code approved by
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
