### PR TITLE
Added a python3.8-venv-pyd4 image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # []
 - Added a `python3.8-venv-d4tools` Dockerfile
+- Added a `python3.8-venv-pyd4` Dockerfile
 
 # [1.1] 2022-02-01
 - Added a `python3.8-slim-bedtools-venv` Dockerfile

--- a/python3.8-venv-pyd4/Dockerfile
+++ b/python3.8-venv-pyd4/Dockerfile
@@ -1,0 +1,54 @@
+###########
+# BUILDER #
+###########
+
+FROM python:3.8-slim as builder
+
+# Install base dependencies
+RUN apt-get update && \
+     apt-get -y upgrade && \
+     apt-get install -y --no-install-recommends build-essential curl git && \
+     apt-get clean && \
+     rm -rf /var/lib/apt/lists/*
+
+# Get Rust
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+# Add .cargo/bin to PATH
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Create a non-root user to install packages into
+RUN groupadd --gid 1000 worker && useradd -g worker --uid 1000 --shell /usr/sbin/nologin --create-home worker
+
+# Install d4tools
+RUN cargo install d4tools --root /home/worker/libs/d4tools
+ENV PATH="/home/worker/libs/d4tools/bin:${PATH}"
+
+ENV PATH="/venv/bin:$PATH"
+
+# Install virtualenv
+RUN pip install --no-cache-dir virtualenv
+RUN virtualenv --seeder pip /venv
+
+# Install pyd4
+RUN pip install --no-cache-dir setuptools-rust pyd4
+
+
+#########
+# FINAL #
+#########
+
+FROM python:3.8-slim
+
+# Create a non-root user to run commands
+RUN groupadd --gid 1000 worker && useradd -g worker --uid 1000 --shell /usr/sbin/nologin --create-home worker
+
+# Copy pre-installed software from builder
+COPY --chown=worker:worker --from=builder /venv /venv
+COPY --chown=worker:worker --from=builder /home/worker/libs /home/worker/libs
+
+ENV PATH="/venv/bin:$PATH"
+ENV PATH="/home/worker/libs/d4tools/bin:${PATH}"
+
+# Run commands as non-root
+USER worker


### PR DESCRIPTION
### This PR adds | fixes:
- Added a very small image (200 Mb compared to the 2 Gb something images containing Cargo) with d4tools and pyd4
- Commands runned from a virtual env containing python 3.8

### How to test:
- Build the image
- Run the container and check that:
  - Contains pyd4
  - d4tools is executable

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
