### PR TITLE
Create an image which contains Python 3.11, Python virtual env and pyd4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # []
 - Added a `d4tools` Dockerfile
 - Added a `python3.8-venv-pyd4` Dockerfile
+- Added a `python3.11-venv-pyd4` Dockerfile
 
 # [1.1] 2022-02-01
 - Added a `python3.8-slim-bedtools-venv` Dockerfile

--- a/python3.11-venv-pyd4/Dockerfile
+++ b/python3.11-venv-pyd4/Dockerfile
@@ -1,0 +1,54 @@
+###########
+# BUILDER #
+###########
+
+FROM python:3.11-slim as builder
+
+# Install base dependencies
+RUN apt-get update && \
+     apt-get -y upgrade && \
+     apt-get install -y --no-install-recommends build-essential curl git && \
+     apt-get clean && \
+     rm -rf /var/lib/apt/lists/*
+
+# Get Rust
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+# Add .cargo/bin to PATH
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Create a non-root user to install packages into
+RUN groupadd --gid 1000 worker && useradd -g worker --uid 1000 --shell /usr/sbin/nologin --create-home worker
+
+# Install d4tools
+RUN cargo install d4tools --root /home/worker/libs/d4tools
+ENV PATH="/home/worker/libs/d4tools/bin:${PATH}"
+
+ENV PATH="/venv/bin:$PATH"
+
+# Install virtualenv
+RUN pip install --no-cache-dir virtualenv
+RUN virtualenv --seeder pip /venv
+
+# Install pyd4
+RUN pip install --no-cache-dir setuptools-rust pyd4
+
+
+#########
+# FINAL #
+#########
+
+FROM python:3.11-slim
+
+# Create a non-root user to run commands
+RUN groupadd --gid 1000 worker && useradd -g worker --uid 1000 --shell /usr/sbin/nologin --create-home worker
+
+# Copy pre-installed software from builder
+COPY --chown=worker:worker --from=builder /venv /venv
+COPY --chown=worker:worker --from=builder /home/worker/libs /home/worker/libs
+
+ENV PATH="/venv/bin:$PATH"
+ENV PATH="/home/worker/libs/d4tools/bin:${PATH}"
+
+# Run commands as non-root
+USER worker


### PR DESCRIPTION
### This PR adds: 
- A python 3.11, venv and pyd4 image

### How to test:
- Build the image with Docker

### Expected outcome:
- [x] image should build without errors

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
