### PR TITLE
Python 3.8 slim bullseye venv Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [1.3] 2023-08-11
+- Added a `python3.8-slim-bullseye-venv` Dockerfile
+
 # [1.2] 2023-05-22
 - Added a `d4tools` Dockerfile
 - Added a `python3.8-venv-pyd4` Dockerfile

--- a/python3.8-slim-bullseye-venv/Dockerfile
+++ b/python3.8-slim-bullseye-venv/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.8-slim-bullseye
+
+ENV PATH="/venv/bin:$PATH"
+
+# Install virtualenv
+RUN pip install virtualenv
+RUN virtualenv --seeder pip /venv
+


### PR DESCRIPTION
### This PR adds | fixes:
- Adds a python3.8-slim-bullseye-venv Dockerfile

### How to test:
- Run `docker build -t python3.8-slim-bullseye-venv .` in the dicrectory that contains the new Dockerfile

### Expected outcome:
- [ ] Make sure Dockerfile builds correctly

### Review:
- [ ] Code approved by
- [ ] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
