### PR TITLE
Python 3.11 + virtual env Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [1.4] 2023-09-27
+- Added a `lsynd` Dockerfile
+- Added a `python3.11-venv` Dockerfile
+
 # [1.3] 2023-08-11
 - Added a `python3.8-slim-bullseye-venv` Dockerfile
 

--- a/python3.11-venv/Dockerfile
+++ b/python3.11-venv/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+
+ENV PATH="/venv/bin:$PATH"
+
+# Install virtualenv
+RUN pip install virtualenv
+RUN virtualenv --seeder pip /venv


### PR DESCRIPTION
### This PR adds
-  A Dockerfile that contains Python 3.11 and virtual environment

### How to test:
- Build the image

### Expected outcome:
The image builds as expected 🆗 

<img width="1043" alt="image" src="https://github.com/Clinical-Genomics/docker-base-images/assets/28093618/2a1fcd67-8f6e-47f6-9561-06f8778abe51">


### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
