### PR TITLE
Add python3.8-slim-bullseye venv + bedtools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,22 @@
+# [1.6] 2023-11-14
+### Changed
+- Changed image `python3.8-slim-bedtools-venv` to `python3.8-slim-bullseye-bedtools-venv`
+
 # [1.5] 2023-11-08
+### Added
 - Added a `python3.11-miniconda` Dockerfile
 
 # [1.4] 2023-09-27
+### Added
 - Added a `lsynd` Dockerfile
 - Added a `python3.11-venv` Dockerfile
 
 # [1.3] 2023-08-11
+### Added
 - Added a `python3.8-slim-bullseye-venv` Dockerfile
 
 # [1.2] 2023-05-22
+### Added
 - Added a `d4tools` Dockerfile
 - Added a `python3.8-venv-pyd4` Dockerfile
 - Added a `python3.11-venv-pyd4` Dockerfile
@@ -17,9 +25,11 @@
 - Added a `python3.8-slim-bedtools-venv` Dockerfile
 
 # [1.0.1] 2022-02-01
+### Fixed
 - Unfreeze cyvcf2 versions
 
 # [1.0.0] -
+### Added
 - Added a Dockefile for the `python3.8-cyvcf2-venv` image
 - Added a Dockefile for the `python3.7.3-slim-stretch-cyvcf2-venv` image
 - Added a Dockerfile for the `python3.8-venv` image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [1.6] 2023-11-14
-### Changed
-- Changed image `python3.8-slim-bedtools-venv` to `python3.8-slim-bullseye-bedtools-venv`
+### Added
+- Added a `python3.8-slim-bullseye-bedtools-venv` image
 
 # [1.5] 2023-11-08
 ### Added

--- a/python3.8-slim-bedtools-venv/Dockerfile
+++ b/python3.8-slim-bedtools-venv/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.8-slim
+
+ENV PATH="/venv/bin:$PATH"
+
+# Install base dependencies
+RUN apt-get update && \
+     apt-get -y upgrade && \
+     apt-get install -y --no-install-recommends wget build-essential gcc zlib1g-dev && \
+     apt-get clean && \
+     rm -rf /var/lib/apt/lists/*
+
+# Download and install bedtools static binary
+RUN cd /usr/local/bin && \
+    wget -q https://github.com/arq5x/bedtools2/releases/download/v2.29.2/bedtools.static.binary && \
+    mv bedtools.static.binary bedtools && \
+    chmod +x bedtools
+
+# Install virtualenv
+RUN pip install virtualenv
+RUN virtualenv --seeder pip /venv

--- a/python3.8-slim-bullseye-bedtools-venv/Dockerfile
+++ b/python3.8-slim-bullseye-bedtools-venv/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.8-slim-bullseye
 
 ENV PATH="/venv/bin:$PATH"
 

--- a/python3.8-slim-bullseye-bedtools-venv/Dockerfile
+++ b/python3.8-slim-bullseye-bedtools-venv/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
 
 # Download and install bedtools static binary
 RUN cd /usr/local/bin && \
-    wget -q https://github.com/arq5x/bedtools2/releases/download/v2.31.1/bedtools.static.binary && \
+    wget -q https://github.com/arq5x/bedtools2/releases/download/v2.30.0/bedtools.static.binary && \
     mv bedtools.static.binary bedtools && \
     chmod +x bedtools
 

--- a/python3.8-slim-bullseye-bedtools-venv/Dockerfile
+++ b/python3.8-slim-bullseye-bedtools-venv/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
 
 # Download and install bedtools static binary
 RUN cd /usr/local/bin && \
-    wget -q https://github.com/arq5x/bedtools2/releases/download/v2.29.2/bedtools.static.binary && \
+    wget -q https://github.com/arq5x/bedtools2/releases/download/v2.31.1/bedtools.static.binary && \
     mv bedtools.static.binary bedtools && \
     chmod +x bedtools
 


### PR DESCRIPTION
### This PR adds | fixes:
- Adds an image with base python3.8-slim-bullseye + virtual env + bedtools 
- This will be the new base image of cgbeacon2 (see #[268](https://github.com/Clinical-Genomics/cgbeacon2/issues/268))

### How to test:
- Build image

### Expected outcome:
- Image should build fine

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
