### PR TITLE
Fix installation of d4tools in python3.11-venv-pyd4 Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [unreleased]
+### Fixed
+- Installation step of d4tools in python3.11-venv-pyd4
+
 # [1.6] 2023-11-14
 ### Added
 - Added a `python3.8-slim-bullseye-bedtools-venv` image

--- a/python3.11-venv-pyd4/Dockerfile
+++ b/python3.11-venv-pyd4/Dockerfile
@@ -21,6 +21,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN groupadd --gid 1000 worker && useradd -g worker --uid 1000 --shell /usr/sbin/nologin --create-home worker
 
 # Install d4tools
+RUN echo 'location' >> ~/.curlrc # https://github.com/38/d4-format/pull/77#issuecomment-2044438359
 RUN cargo install d4tools --root /home/worker/libs/d4tools
 ENV PATH="/home/worker/libs/d4tools/bin:${PATH}"
 


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #21 

**How to prepare for test**:
- Build the image

### How to test:
- Make sure that the image builds 

### Expected outcome:
- [x] Run the image in interactive mode and make sure d4tools and pyd4 are installed

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
