### PR TITLE
Use d4tools 0.3.10 in python3.11-venv-d4tools Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [unreleased]
 ### Added
 - `python3.11-venv-d4tools` Dockerfile - not containing the pyd4 library
+- Use d4tools 0.3.10 in `python3.11-venv-d4tools` Dockerfile - install via git with tag
 ### Fixed
 - Installation step of d4tools in python3.11-venv-pyd4
 

--- a/python3.11-venv-d4tools/Dockerfile
+++ b/python3.11-venv-d4tools/Dockerfile
@@ -21,8 +21,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN groupadd --gid 1000 worker && useradd -g worker --uid 1000 --shell /usr/sbin/nologin --create-home worker
 
 # Install d4tools
-RUN echo 'location' >> ~/.curlrc # https://github.com/38/d4-format/pull/77#issuecomment-2044438359
-RUN cargo install d4tools --root /home/worker/libs/d4tools
+RUN cargo install --git https://github.com/38/d4-format.git d4tools --tag v0.3.10 --root /home/worker/libs/d4tools
 ENV PATH="/home/worker/libs/d4tools/bin:${PATH}"
 
 ENV PATH="/venv/bin:$PATH"


### PR DESCRIPTION
## Description
### Changed
- Use the latest d4tools in `python3.11-venv-d4tools` Dockerfile (closes #25)

### How to test
- [x] Build and run the image interactively and check that d4tools has the expected version

## Review
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
