### PR TITLE
d4tools-based images to use GitHub branch master when cargo installs d4tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # [unreleased]
 ### Added
 - `python3.11-venv-d4tools` Dockerfile - not containing the pyd4 library
-- Use d4tools 0.3.10 in `python3.11-venv-d4tools` Dockerfile - install via git with tag
 ### Changed
 - Issue templates
+- Modified d4tools-based images to use GitHub branch main when cargo installs d4tools 
 ### Fixed
 - Installation step of d4tools in python3.11-venv-pyd4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - `python3.11-venv-d4tools` Dockerfile - not containing the pyd4 library
 ### Changed
 - Issue templates
-- Modified d4tools-based images to use GitHub branch main when cargo installs d4tools 
+- Modified d4tools-based images to use GitHub branch master when cargo installs d4tools 
 ### Fixed
 - Installation step of d4tools in python3.11-venv-pyd4
 - "GLIBC_2.x not found" error in d4tools image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Modified d4tools-based images to use GitHub branch main when cargo installs d4tools 
 ### Fixed
 - Installation step of d4tools in python3.11-venv-pyd4
+- "GLIBC_2.x not found" error in d4tools image
 
 # [1.6] 2023-11-14
 ### Added

--- a/d4tools/Dockerfile
+++ b/d4tools/Dockerfile
@@ -10,7 +10,7 @@ RUN cargo install --git https://github.com/38/d4-format.git d4tools --branch mas
 # FINAL #
 #########
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 # Import lib from builder
 COPY --from=builder /usr/local/cargo/bin/d4tools /usr/local/bin/d4tools

--- a/d4tools/Dockerfile
+++ b/d4tools/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM rust:latest AS builder
 
-RUN cargo install d4tools
+RUN cargo install --git https://github.com/38/d4-format.git d4tools --branch master
 
 #########
 # FINAL #

--- a/python3.11-venv-d4tools/Dockerfile
+++ b/python3.11-venv-d4tools/Dockerfile
@@ -21,7 +21,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN groupadd --gid 1000 worker && useradd -g worker --uid 1000 --shell /usr/sbin/nologin --create-home worker
 
 # Install d4tools
-RUN cargo install --git https://github.com/38/d4-format.git d4tools --tag v0.3.10 --root /home/worker/libs/d4tools
+RUN cargo install --git https://github.com/38/d4-format.git d4tools --branch master --root /home/worker/libs/d4tools
 ENV PATH="/home/worker/libs/d4tools/bin:${PATH}"
 
 ENV PATH="/venv/bin:$PATH"

--- a/python3.11-venv-pyd4/Dockerfile
+++ b/python3.11-venv-pyd4/Dockerfile
@@ -22,7 +22,7 @@ RUN groupadd --gid 1000 worker && useradd -g worker --uid 1000 --shell /usr/sbin
 
 # Install d4tools
 RUN echo 'location' >> ~/.curlrc # https://github.com/38/d4-format/pull/77#issuecomment-2044438359
-RUN cargo install d4tools --root /home/worker/libs/d4tools
+RUN cargo install --git https://github.com/38/d4-format.git d4tools --branch master --root /home/worker/libs/d4tools
 ENV PATH="/home/worker/libs/d4tools/bin:${PATH}"
 
 ENV PATH="/venv/bin:$PATH"


### PR DESCRIPTION
## Description
### Changed
- Modified d4tools-based images to use GitHub branch main when cargo installs d4tools  (closes #29)
### Fixed
- "GLIBC_2.x not found" error in d4tools image (fix #32 )

### How to test
- [x] Build the images and make sure they have they can be executed with the latest feature (stat perc_cov)

## Review
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
