### PR TITLE
Add instructions on how to build/tag/push the images to our Docker Hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Added
 - `python3.11-venv-d4tools` Dockerfile - not containing the pyd4 library
 - Use d4tools 0.3.10 in `python3.11-venv-d4tools` Dockerfile - install via git with tag
+- Instructions on how to build/tag/push the images to our Docker Hub
 ### Changed
 - Issue templates
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ A collection of useful Dockerfiles to be used as base images for more advanced D
 
 ```docker build -t <name-of-image> --platform linux/amd64 ```
 
-docker build 
 
 ### Tag an image
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # docker-base-images
 A collection of useful Dockerfiles to be used as base images for more advanced Dockerfiles
+
+### Build an image
+
+```docker build -t <name-of-image> --platform linux/amd64 ```
+
+docker build 
+
+### Tag an image
+
+```docker tag <name-of-image> clinicalgenomics/<name-of-image>:<tag>```
+
+
+### Push the image to ClinicalGenomics Docker Hub:
+
+```docker push clinicalgenomics/<name-of-image>:<tag>```


### PR DESCRIPTION
## Description

### Added

- Instructions on how to build/tag/push the images to our Docker Hub (closes #30)

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
